### PR TITLE
Pulse 444 멘토링 리스트 api 연동

### DIFF
--- a/src/contracts/response/mentoring-list/mentoring-list.reseponse.dto.ts
+++ b/src/contracts/response/mentoring-list/mentoring-list.reseponse.dto.ts
@@ -1,0 +1,36 @@
+// 강의 타입
+export type LectureType = "ONLINE" | "OFFLINE";
+
+// 단일 멘토링 항목 DTO
+export interface MentoringListItemDto {
+  mentoring_id: string;                   // 멘토링 고유 ID
+  lecture_type: LectureType;             // 강의 형태
+  title: string;                         // 멘토링 제목
+  mentor_profile_image: string;          // 멘토 프로필 이미지
+  mentor_job: string;                    // 멘토 직업명
+  mentor_career_total_year: number;      // 멘토 총 경력 (년 단위)
+  online_platform: string;               // 온라인 플랫폼명
+  mentor_nickname: string;               // 멘토 닉네임
+  deadline_time: string;                 // 신청 마감 시간 (ISO8601)
+  view_count: number;                    // 조회 수
+  is_bookmark: boolean;                  // 북마크 여부
+}
+
+// 페이징 정보 및 멘토링 리스트 포함한 응답
+export interface PaginationDto<T> {
+  page: number;                          // 현재 페이지 번호
+  size: number;                          // 한 페이지당 아이템 수
+  sort: "ASC" | "DESC";                  // 정렬 방식
+  total_pages: number;                   // 전체 페이지 수
+  total_count: number;                   // 전체 항목 수
+  contents: T[];                         // 실제 데이터 리스트
+}
+
+// API 기본 응답 구조
+export interface ResultData<T> {
+  body: T;                               // 응답 데이터 본문
+  message: string;                       // 응답 메시지
+}
+
+// 최종 응답 타입 (ResultData + Pagination + Mentoring 리스트)
+export type MentoringListResponseDto = ResultData<PaginationDto<MentoringListItemDto>>;

--- a/src/features/main/component/card.tsx
+++ b/src/features/main/component/card.tsx
@@ -1,103 +1,29 @@
+import { MentoringListItemDto } from "@/contracts/response/mentoring-list/mentoring-list.reseponse.dto";
 import { MentorCard } from "@/shared/components";
 
-interface Mentoring {
-  mentoring_id: string;
-  title: string;
-  mentor_nickname: string;
-  deadline_time: string;
-  mentor_job: { jobCode: string };
-  mentor_profile_image: string | null;
-  lecture_type: "ONLINE" | "OFFLINE";
+interface Props {
+  list: MentoringListItemDto[];
 }
 
-const dummyMentoringList: Mentoring[] = [
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-  {
-    mentoring_id: "1",
-    title: "제목입니다 제목은 세 줄까지지만 보입니다",
-    mentor_nickname: "찡구는목말라",
-    deadline_time: "2025-03-02",
-    mentor_job: { jobCode: "UI/UX" },
-    mentor_profile_image: "/profile.png",
-    lecture_type: "ONLINE",
-  },
-];
-
-export const MainCardList = () => {
+export const MainCardList = ({ list }: Props) => {
+  console.log("받은 리스트:", list); 
   return (
+    
     <div className="mentoring-card-grid">
-      {dummyMentoringList.map((item) => (
+      {list.map((item) => (
         <MentorCard
           key={item.mentoring_id}
           mentoringId={item.mentoring_id}
-          onlineStatus={item.lecture_type === "ONLINE" ? "온라인" : "오프라인"}
           title={item.title}
           mentorNickname={item.mentor_nickname}
           deadlineDate={item.deadline_time}
-          mentorJob={item.mentor_job.jobCode}
+          mentorJob={item.mentor_job}
+          mentorCareer={item.mentor_career_total_year}
           mentorProfileImage={item.mentor_profile_image}
+          lectureType={item.lecture_type}
+          onlinePlatform={item.online_platform}
+          region={""} 
+          onlineStatus={item.lecture_type === "ONLINE" ? "온라인" : "오프라인"}
         />
       ))}
     </div>

--- a/src/features/main/main.view.tsx
+++ b/src/features/main/main.view.tsx
@@ -4,6 +4,7 @@ import { FindMentorSection } from "./component/findMentor";
 import { usePageNavigation } from "@/shared/lib/hooks";
 
 import { Icon } from "@/shared/components";
+import { MainCardListContainer } from "../mentoring-list/\bmentoring-list-container";
 
 export const MainView = () =>  {
 
@@ -30,7 +31,7 @@ export const MainView = () =>  {
         </div>
 
         {/* 나중에 API 연동해서 카드 8개 노출 */}
-        <MainCardList />
+        <MainCardListContainer/>
         </section>
 
       {/* 맞춤 멘토 찾기 */}

--- a/src/features/mentor-check/mentor-check.service.tsx
+++ b/src/features/mentor-check/mentor-check.service.tsx
@@ -1,13 +1,24 @@
 import { privateClient } from "@/networks/client";
 
 
+
+
+interface MentorCheckResponse {
+  body: boolean;
+  message: string;
+}
+
 export const checkMentorRegistered = async (): Promise<boolean> => {
   try {
-    const res = await privateClient.get("/mento-info/exist") as { isRegistered: boolean };
-    return res.isRegistered;
+    const res: MentorCheckResponse = await privateClient.get("/mento-info/exist");
+    console.log("[멘토 등록 여부 응답]", res);
 
+    return res.body;
+    
   } catch (err) {
     console.error("멘토 등록 여부 확인 실패:", err);
     return false;
   }
+
 };
+

--- a/src/features/mentoring-list/mentoring-list-container.tsx
+++ b/src/features/mentoring-list/mentoring-list-container.tsx
@@ -1,0 +1,12 @@
+import { useMentoringList } from "./mentoring-list.controller";
+import { MainCardList } from "../main/component/card";
+import { MentoringListItemDto } from "@/contracts/response/mentoring-list/mentoring-list.reseponse.dto";
+
+export const MainCardListContainer = () => {
+  const { data, isLoading, isError } = useMentoringList();
+
+  if (isLoading) return <p>로딩 중...</p>;
+  if (isError || !data) return <p>에러 발생</p>;
+
+  return <MainCardList list={data.body.contents as MentoringListItemDto[]} />;
+};

--- a/src/features/mentoring-list/mentoring-list.controller.tsx
+++ b/src/features/mentoring-list/mentoring-list.controller.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { gethMentoringList } from "@/networks/apis/mentoring-list.api";
+import { MentoringListItemDto } from "@/contracts/response/mentoring-list/mentoring-list.reseponse.dto";
+
+// 한국 시간 변환 함수
+const convertToKoreanDate = (isoDate: string): string => {
+  const date = new Date(isoDate);
+  const koreanTime = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return koreanTime.toISOString().split("T")[0]; 
+};
+
+export const useMentoringList = () => {
+  return useQuery({
+    queryKey: ["mentoringList"],
+    queryFn: async () => {
+      const res = await gethMentoringList();
+
+      //  모든 항목의 deadline_time을 가공
+      const convertedContents = res.body.contents.map((item): MentoringListItemDto => ({
+        ...item,
+        deadline_time: convertToKoreanDate(item.deadline_time),
+      }));
+
+      return {
+        ...res,
+        body: {
+          ...res.body,
+          contents: convertedContents,
+        },
+      };
+    },
+  });
+};

--- a/src/networks/apis/mentoring-list.api.ts
+++ b/src/networks/apis/mentoring-list.api.ts
@@ -1,0 +1,19 @@
+import {
+  ResultData,
+  PaginationDto,
+  MentoringListItemDto,
+} from "@/contracts/response/mentoring-list/mentoring-list.reseponse.dto";
+
+import { publicClient } from "../client";
+
+export const gethMentoringList = async (): Promise<ResultData<PaginationDto<MentoringListItemDto>>> => {
+    const res = await publicClient.get("/mentoring/list", {
+      params: { page: 1, size: 8 },  // 가져와지는 
+    }) as ResultData<PaginationDto<MentoringListItemDto>>;
+  
+    console.log("body:", res.body);
+  
+    return res;
+  };
+  
+  

--- a/src/shared/components/blocks/cards/bodyContentTag.tsx
+++ b/src/shared/components/blocks/cards/bodyContentTag.tsx
@@ -1,0 +1,49 @@
+import { Icon, Image, SquareBadge } from "@/shared/components/atoms";
+
+// Body
+const BodyContentTitle = ({ title, onClick }: { title: string; onClick?: () => void }) => {
+    return <span onClick={onClick}>{title}</span>;
+  };
+  
+  const BodyContentTag = ({ job, career, lectureType, platform, region, profileImage }: { job: string; career: number; lectureType: "ONLINE" | "OFFLINE"; platform: string; region: string; profileImage: string }) => {
+    // 조건부 표시 값 설정
+    const locationOrPlatform = lectureType === "OFFLINE" ? region : platform?.trim() || "미정";
+  
+    const locationLabel = lectureType === "OFFLINE" ? "지역" : "플랫폼";
+  
+    return (
+      <div className="mentorCard-content__tag">
+        <div className="content__tag left">
+          <label className="flex_r flex_ac">
+            <Icon src="id_badge" alt="사원증" />
+            <span className="m-l-4">{job}</span>
+          </label>
+          <label className="flex_r flex_ac">
+            <Icon src="briefcase_20" alt="서류가방" />
+            <span className="m-l-4">경력 {career}년</span>
+          </label>
+          <label className="flex_r flex_ac">
+            <Icon src="desktop" alt="데스크탑" />
+            <span className="m-l-4">
+              {locationLabel} : {locationOrPlatform}
+            </span>
+          </label>
+        </div>
+        <div className="content__tag right">
+          <Image className="mentorCard-img" src={profileImage || "profile 1"} alt="프로필" />
+        </div>
+      </div>
+    );
+  };
+  
+  // Footer
+  const FooterDescription = ({ deadlineDate, mentorNickname }: { deadlineDate: string; mentorNickname: string }) => {
+    return (
+      <div className="mentorCard-footer__desc">
+        <span className="footer__desc date">~{deadlineDate}</span>
+        <span className="footer__desc nickname">{mentorNickname}</span>
+      </div>
+    );
+  };
+
+  export {BodyContentTag,BodyContentTitle,FooterDescription};

--- a/src/shared/components/blocks/cards/mentorCard.tsx
+++ b/src/shared/components/blocks/cards/mentorCard.tsx
@@ -1,67 +1,24 @@
-import { Icon, Image, SquareBadge } from "@/shared/components/atoms";
+import {SquareBadge } from "@/shared/components/atoms";
+import { BodyContentTag,BodyContentTitle,FooterDescription } from "./bodyContentTag";
 import { BaseCard } from "./baseCard";
-
 import { Link } from "react-router-dom";
 import { BookmarkButton } from "../bookmark/bookmarkButton";
 
-// Body
-const BodyContentTitle = ({ title, onClick }: { title: string; onClick?: () => void }) => {
-  return <span onClick={onClick}>{title}</span>;
-};
-
-const BodyContentTag = ({ job, career, lectureType, platform, region, profileImage }: { job: string; career: number; lectureType: "ONLINE" | "OFFLINE"; platform: string; region: string; profileImage: string }) => {
-  // 조건부 표시 값 설정
-  const locationOrPlatform = lectureType === "OFFLINE" ? region : platform?.trim() || "미정";
-
-  const locationLabel = lectureType === "OFFLINE" ? "지역" : "플랫폼";
-
-  return (
-    <div className="mentorCard-content__tag">
-      <div className="content__tag left">
-        <label className="flex_r flex_ac">
-          <Icon src="id_badge" alt="사원증" />
-          <span className="m-l-4">{job}</span>
-        </label>
-        <label className="flex_r flex_ac">
-          <Icon src="briefcase_20" alt="서류가방" />
-          <span className="m-l-4">경력 {career}년</span>
-        </label>
-        <label className="flex_r flex_ac">
-          <Icon src="desktop" alt="데스크탑" />
-          <span className="m-l-4">
-            {locationLabel} : {locationOrPlatform}
-          </span>
-        </label>
-      </div>
-      <div className="content__tag right">
-        <Image className="mentorCard-img" src={profileImage || "profile 1"} alt="프로필" />
-      </div>
-    </div>
-  );
-};
-
-// Footer
-const FooterDescription = ({ deadlineDate, mentorNickname }: { deadlineDate: string; mentorNickname: string }) => {
-  return (
-    <div className="mentorCard-footer__desc">
-      <span className="footer__desc date">~{deadlineDate}</span>
-      <span className="footer__desc nickname">{mentorNickname}</span>
-    </div>
-  );
-};
 
 interface MentorCardProps {
-  mentoringId: string;
-  title: string;
-  mentorNickname: string;
-  deadlineDate: string;
-  mentorJob: string;
-  mentorCareer: number;
-  mentorProfileImage: string;
-  lectureType: "ONLINE" | "OFFLINE";
-  onlinePlatform: string;
-  region: string;
+  mentoringId: string;           // 멘토링 고유 ID (백엔드 제공)
+  onlineStatus: string;          // 온/오프라인 여부 (가공됨: "온라인" | "오프라인")
+  title: string;                 // 멘토링 제목
+  mentorNickname: string;        // 멘토 닉네임
+  deadlineDate: string;          // 마감 날짜 (가공됨: YYYY-MM-DD 형식)
+  mentorJob: string;             // 멘토 직무명
+  mentorCareer: number;          // 멘토 총 경력 년수
+  mentorProfileImage: string;    // 멘토 프로필 이미지 경로
+  lectureType: "ONLINE" | "OFFLINE"; // 강의 형태 (백엔드 원본 값)
+  onlinePlatform: string;        // 온라인 플랫폼명 (예: Zoom 등)
+  region: string;                // 오프라인 강의 지역명 (lectureType이 OFFLINE일 때 사용)
 }
+
 
 // Mentor Card Component
 export const MentorCard = ({ mentoringId, title, mentorNickname, deadlineDate, mentorJob, mentorCareer, mentorProfileImage, lectureType, onlinePlatform, region }: MentorCardProps) => {

--- a/src/shared/lib/utils/menuActionMap.ts
+++ b/src/shared/lib/utils/menuActionMap.ts
@@ -14,18 +14,25 @@ type MenuAction = (
 export const menuActionMap: Record<string, MenuAction> = {
   handleMentorInfo: async (navigate, context, item) => {
     if (!context.isLogin) {
-      alert('로그인을 하고 오십시오');
+
+      alert('로그인 후 이용가능합니다.');
+
       navigate("/auth/signIn");
       return;
     }
 
-    // 멘토 등록 여부 확인 로직은 여기에 나중에 추가
+    
+
     const isMentorRegistered = await checkMentorRegistered();
 
-    if (!isMentorRegistered) {
-      navigate(item?.href ?? "/mentor-register");
+    if (isMentorRegistered) {
+      alert("이미 멘토로 등록되어있습니다.");
+      setTimeout(() => {
+        navigate("/mentor-find");
+      }, 100); 
     } else {
-      alert("등록이 되어있습니다.");
+      navigate(item?.href ?? "/mentor-register");
+
     }
   },
 };


### PR DESCRIPTION
## ✨어떤 기능인가요?
>API 응답 타입과 화면 렌더링용 props 타입을 분리하여 유지보수성을 높였으며, 멘토링 리스트 데이터를 성공적으로 연동하여 화면에 출력

## ✔️TODOS
- [ ] 서버 응답 타입(dto(과 컴포넌트 props 타입은 역할에 따라 분리해서 작성
- [ ] API 함수는 응답 원본만 반환하고, 데이터 가공은 controller(useQuery)에서 처리


## 🎶테스트 방법
>공식 문서, 개발 블로그, 강의 자료 등 자유롭게 첨부해주세요.
