### PR TITLE
Pulse 452 멘토링 글 등록 api 연동 (#136)

### DIFF
--- a/src/features/posts/posts.controller.tsx
+++ b/src/features/posts/posts.controller.tsx
@@ -49,8 +49,8 @@ const PostfailAlert = ({ id, closeModal }: RegisterAlertProps) => {
 
   return (
     <Alert
-      title="멘티 모집글 등록"
-      body="멘토등록은 5개 까지만 가능합니다."
+      title="멘티 모집글 등록 실패"
+      body="멘티 모집글은 멘토로 등록된 사용자만 작성할 수 있습니다."
       cancelBtn={false}
       confirmText="확인"
       onConfirm={() => {

--- a/src/features/posts/posts.view.tsx
+++ b/src/features/posts/posts.view.tsx
@@ -708,7 +708,13 @@ export const PostsView = (props: PostsViewProps) => {
           <BaseButton type="button" size="lg" color="reverse" onClick={props.onCancel}>
             취소
           </BaseButton>
-          <BaseButton size="lg" type="submit" className={isFormValid ? "primary " : "reverse"} disabled={!isFormValid}>
+          <BaseButton 
+              size="lg" 
+              type="submit" 
+              className={isFormValid ? "primary " : "reverse"} 
+              disabled={!isFormValid}
+              onClick={handleSubmit}
+          >
             신청
           </BaseButton>
         </div>

--- a/src/networks/apis/post.api.ts
+++ b/src/networks/apis/post.api.ts
@@ -1,18 +1,34 @@
 import { MentoringPostRequestDTO } from "@/contracts/request/post/post.request.dto";
 import { privateClient } from "../client";
+import { checkMentorRegistered } from "@/features/mentor-check/mentor-check.service";
 /**
  * 멘토링 등록 API 호출 함수
  * @param payload - 멘토링 등록 요청 데이터
  * @returns ResultData<ResultCodes>
  */
 
+
+
 export const postMentoring = async (payload: MentoringPostRequestDTO): Promise<{ body: "SUCCESS"; message: string }> => {
+  
+  // 1. 사전 확인
+  const isMentor = await checkMentorRegistered();
+  if (!isMentor) {
+    throw {
+      status: 403,
+      body: "MENTO_NOT_REGISTERED_USER",
+      message: "멘토로 등록되지 않은 사용자입니다. 글을 등록할 수 없습니다.",
+    };
+  }
+
+  // 2. 글 등록 시도
   try {
     const response = await privateClient.post("/mentoring/post", payload);
+    console.log("멘티모집 글 등록 성공!:", response.data.message); 
     return response.data;
   } catch (error: any) {
     if (error.response) {
-      console.error("Mentoring registration failed:", error.response.data);
+      console.error("맨토모집 글 등록 실패:", error.response.data);
     } else {
       console.error("Network or other error:", error.message);
     }

--- a/src/networks/client/private.client.ts
+++ b/src/networks/client/private.client.ts
@@ -9,93 +9,120 @@ const privateClient = axios.create({
   baseURL: baseUrl,
 });
 
-// 토큰 안전하게 추출
-// getToken 수정
-const getToken = (): string | null => {
-  const raw = localStorage.getItem("pulse");
-  return raw ?? null; //  JSON.parse 제거
+// 토큰 가져오기
+const getAccessToken = (): string | null => {
+  try {
+    const pulse = JSON.parse(localStorage.getItem("pulse") || "{}");
+    return pulse?.token ?? null;
+  } catch (e) {
+    return null;
+  }
 };
 
-// 요청 시 헤더에 토큰 자동 부착
-privateClient.interceptors.request.use(
-  async (config: any) => {
-    const token = getToken();
+const getRefreshToken = (): string | null => {
+  try {
+    const pulse = JSON.parse(localStorage.getItem("pulse") || "{}");
+    return pulse?.refreshToken ?? null;
+  } catch (e) {
+    return null;
+  }
+};
 
+
+// 토큰 재발급 요청
+const refreshAccessToken = async (): Promise<string | null> => {
+  try {
+    const refreshToken = getRefreshToken();
+    if (!refreshToken) return null;
+
+    const res = await axios.post(`${baseUrl}/auth/refresh`, {
+      refreshToken,
+    });
+
+    const newAccessToken = res.data?.accessToken;
+    const newRefreshToken = res.data?.refreshToken;
+
+    if (newAccessToken) {
+      localStorage.setItem(
+        "pulse",
+        JSON.stringify({
+          token: newAccessToken,
+          refreshToken: newRefreshToken ?? refreshToken,
+        })
+      );
+      return newAccessToken;
+    }
+
+    return null;
+  } catch (err) {
+    console.error("토큰 재발급 실패:", err);
+    return null;
+  }
+};
+
+// 요청 시 토큰 자동 추가
+
+privateClient.interceptors.request.use(
+  
+  async (config: any) => {
+
+    const token = getAccessToken();
+    
     return {
       ...config,
-      withCredentials: true,
       headers: {
         "Content-type": "application/json;charset=UTF-8",
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
     };
   },
-  (error) => {
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
 
-// 응답 타입이 문자열(JWT 등)일 경우도 처리
+// 응답에서 토큰 만료 감지 및 자동 재시도
 privateClient.interceptors.response.use(
   (response) => {
-    const contentType = response.headers["content-type"];
-
-    const isJson = typeof response.data === "object" && contentType?.includes("application/json");
-
-    if (isJson) {
-      console.info("응답을 받았습니다.");
+    if (response && response.data) {
       return response.data;
     }
-
-    console.warn("응답이 JSON이 아닙니다.");
-    return response.data;
+    return response;
+    
   },
-  (error) => {
+  async (error) => {
+    const originalRequest = error.config;
+
+    const isTokenExpired =
+      error.response?.status === 417 &&
+      error.response?.data?.body === "TOKEN_EXPIRED";
+
+    // 재시도 플래그로 무한 루프 방지
+    if (isTokenExpired && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const newToken = await refreshAccessToken();
+        if (newToken) {
+          originalRequest.headers = {
+            ...(originalRequest.headers || {}),
+            Authorization: `Bearer ${newToken}`,
+          };
+          return privateClient(originalRequest); //재요청
+        }
+      } catch (e) {
+        // 갱신 호출 자체 실패 시 아래로 떨어져 로그아웃
+      }
+
+      console.warn("토큰 갱신 실패. 로그아웃 처리 필요");
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("refreshToken");
+      alert("토큰 갱신 실패. 로그아웃됩니다.");
+      location.href="/auth/signIn";
+      return Promise.reject(error);
+    }
+
     return Promise.reject(error);
   }
 );
 
 export default privateClient;
 
-//
-// import { envConst } from "@/shared/constants";
-// import axios from "axios";
-// import { localStorageManager } from "taeo-utils";
-
-// const { server, server_port } = envConst;
-
-// const baseUrl = import.meta.env.MODE === "production" ? "/api" : server + server_port + "/api/v1";
-// //백엔드와 프로덕션환경에 대해 이야기 해보아야함
-// const privateClient = axios.create({
-//   baseURL: baseUrl,
-// });
-
-// privateClient.interceptors.request.use(
-//   async (config: any) => {
-//     return {
-//       ...config,
-//       headers: {
-//         "Content-type": "application/json;charset=UTF-8",
-//         Authorization: Bearer ${JSON.parse(localStorage.getItem("pulse") || "{}").token},
-//       },
-//     };
-//   },
-//   (error) => {
-//     return Promise.reject(error);
-//   }
-// );
-
-// privateClient.interceptors.response.use(
-//   (response) => {
-//     if (response && response.data) {
-//       console.info("응답을 받았습니다.");
-//       return response.data;
-//     }
-//     return response;
-//   },
-//   (error) => {
-//     return Promise.reject(error);
-//   }
-// );
-
-// export default privateClient;

--- a/src/shared/components/blocks/cards/mentorCard.tsx
+++ b/src/shared/components/blocks/cards/mentorCard.tsx
@@ -1,3 +1,4 @@
+
 import { SquareBadge } from "@/shared/components/atoms";
 import { BodyContentTag, BodyContentTitle, FooterDescription } from "./bodyContentTag";
 import { BaseCard } from "./baseCard";
@@ -5,17 +6,20 @@ import { Link } from "react-router-dom";
 import { BookmarkButton } from "../bookmark/bookmarkButton";
 
 interface MentorCardProps {
-  mentoringId: string; // 멘토링 고유 ID (백엔드 제공)
-  title: string; // 멘토링 제목
-  mentorNickname: string; // 멘토 닉네임
-  deadlineDate: string; // 마감 날짜 (가공됨: YYYY-MM-DD 형식)
-  mentorJob: string; // 멘토 직무명
-  mentorCareer: number; // 멘토 총 경력 년수
-  mentorProfileImage: string; // 멘토 프로필 이미지 경로
+  mentoringId: string;           // 멘토링 고유 ID (백엔드 제공)
+  onlineStatus: string;          // 온/오프라인 여부 (가공됨: "온라인" | "오프라인")
+  title: string;                 // 멘토링 제목
+  mentorNickname: string;        // 멘토 닉네임
+  deadlineDate: string;          // 마감 날짜 (가공됨: YYYY-MM-DD 형식)
+  mentorJob: string;             // 멘토 직무명
+  mentorCareer: number;          // 멘토 총 경력 년수
+  mentorProfileImage: string;    // 멘토 프로필 이미지 경로
   lectureType: "ONLINE" | "OFFLINE"; // 강의 형태 (백엔드 원본 값)
-  onlinePlatform: string; // 온라인 플랫폼명 (예: Zoom 등)
-  region: string; // 오프라인 강의 지역명 (lectureType이 OFFLINE일 때 사용)
+  onlinePlatform: string;        // 온라인 플랫폼명 (예: Zoom 등)
+  region: string;                // 오프라인 강의 지역명 (lectureType이 OFFLINE일 때 사용)
+
 }
+
 
 // Mentor Card Component
 export const MentorCard = ({ mentoringId, title, mentorNickname, deadlineDate, mentorJob, mentorCareer, mentorProfileImage, lectureType, onlinePlatform, region }: MentorCardProps) => {

--- a/src/shared/constants/const/sideMenu.const.ts
+++ b/src/shared/constants/const/sideMenu.const.ts
@@ -5,7 +5,7 @@ export const SideMenuConst = Object.assign(
       FLOATING_MENU: [
         { title: "멘토정보", href: "/mentor-register", iconSrc: "mentorinfo",onClick: "handleMentorInfo" },
         { title: "북마크 목록", href: "/bookmarks", iconSrc: "bookmark_20" },
-        { title: "멘티모집", href: "/posts", iconSrc: "pencile" },
+        { title: "멘티모집", href: "/posts", iconSrc: "pencile", onClick: "handleMenteeRecruit" },
       ],
     },
   }

--- a/src/shared/lib/utils/menuActionMap.ts
+++ b/src/shared/lib/utils/menuActionMap.ts
@@ -12,16 +12,13 @@ type MenuAction = (
 ) => void | Promise<void>;
 
 export const menuActionMap: Record<string, MenuAction> = {
+  /*멘토정보 클릭시 작동*/
   handleMentorInfo: async (navigate, context, item) => {
     if (!context.isLogin) {
-
       alert('로그인 후 이용가능합니다.');
-
       navigate("/auth/signIn");
       return;
     }
-
-    
 
     const isMentorRegistered = await checkMentorRegistered();
 
@@ -32,7 +29,26 @@ export const menuActionMap: Record<string, MenuAction> = {
       }, 100); 
     } else {
       navigate(item?.href ?? "/mentor-register");
+    }
+  },
 
+  /*멘티모집 클릭시 작동*/
+  handleMenteeRecruit:  async (navigate, context, item) => {
+    if (!context.isLogin) {
+      alert('로그인 후 이용가능합니다.');
+      navigate("/auth/signIn");
+      return;
+    }
+
+    const isMentorRegistered = await checkMentorRegistered();
+
+    if (!isMentorRegistered) {
+      alert("멘토로 등록된 사람만 이용이 가능합니다");
+      setTimeout(() => {
+        navigate("/mentor-find");
+      }, 100); 
+    } else {
+      navigate(item?.href ?? "/mentor-register");
     }
   },
 };


### PR DESCRIPTION
* 메인 멘토링 리스트 api 연동  (#134)

* 메인화면에 멘토등록카드 가져오기 api 연동, 추후 수정 필요

* 멘토링 메인 리스트 api 연동 수정

* 멘티 신청 post 등록 로직 및 prviateClient로직 수정 1차

* post.api console추가

* privateClinet 추가 수정

* 멘티모집 클릭시 로그인 여부 및 멘토 여부 확인하는 로직 구현

---------


## ✨어떤 기능인가요?
>추가하려는 기능에 대한 간단한 설명을 해주세요

## ✔️TODOS
- [ ] privateClient수정 내용 : 
-> 기존 : 토큰 만료시 refresh토큰 재발급 안 됨
-> 수정 : 토큰 만료시 refresh토큰 재발급
- [ ] TODO
- [ ] TODO

## 🎶테스트 방법
>공식 문서, 개발 블로그, 강의 자료 등 자유롭게 첨부해주세요.
